### PR TITLE
Update base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.5.42-jdk11-openjdk-slim
+FROM tomcat:8.5.51-jdk11-openjdk-slim
 
 LABEL Maintaner JamfDevops <devops@jamf.com>
 


### PR DESCRIPTION
JAMF has identified a security vulnerability with Tomcat that has been patched in version 8.5.51.  Verified works fine and does not alter any functionality; but simply patches the identified issue.